### PR TITLE
Add a method to delete item from a matrix without triggering similarity calculations

### DIFF
--- a/lib/predictor/base.rb
+++ b/lib/predictor/base.rb
@@ -272,6 +272,15 @@ module Predictor::Base
     return self # rubocop:disable Style/RedundantReturn
   end
 
+  def delete_from_matrix(matrix, item)
+    # Deleting from a specific matrix without triggering similarity
+    # calculations of related items
+
+    input_matrices[matrix].delete_item(item)
+
+    return self
+  end
+
   def delete_from_matrix!(matrix, item)
     # Deleting from a specific matrix, so get related_items, delete, then update the similarity of those related_items
     items = related_items(item)


### PR DESCRIPTION
Add a method to delete an item from a matrix without triggering similarity calculations (`add_to_matrix` as opposed to `add_to_matrix!`).